### PR TITLE
ViasNeighborRadius setting

### DIFF
--- a/Deroute/FormSettings.cs
+++ b/Deroute/FormSettings.cs
@@ -133,6 +133,8 @@ namespace DerouteSharp
 			public int MinimapViewportOpacity { get; set; }
 			[Description("Minimum size of the minimap in pixels.")]
 			public int MinimapMinSize { get; set; }
+			[Description("Radius in lambda for checking neighbor viases when adding new vias. Vias within this distance will not be created.")]
+			public float ViasNeighborRadius { get; set; }
 
 			private EntityBox savedEntityBox;
 			public GlobalSettings() { }
@@ -166,6 +168,8 @@ namespace DerouteSharp
 				MinimapViewportColor = entityBox.MinimapViewportColor;
 				MinimapViewportOpacity = entityBox.MinimapViewportOpacity;
 				MinimapMinSize = entityBox.MinimapMinSize;
+
+				ViasNeighborRadius = entityBox.ViasNeighborRadius;
 			}
 
 			public void Save()
@@ -192,6 +196,8 @@ namespace DerouteSharp
 				savedEntityBox.MinimapViewportColor = MinimapViewportColor;
 				savedEntityBox.MinimapViewportOpacity = MinimapViewportOpacity;
 				savedEntityBox.MinimapMinSize = MinimapMinSize;
+
+				savedEntityBox.ViasNeighborRadius = ViasNeighborRadius;
 			}
 		}
 
@@ -501,6 +507,7 @@ namespace DerouteSharp
 			global.MinimapViewportColor = settings.MinimapViewportColor;
 			global.MinimapViewportOpacity = settings.MinimapViewportOpacity;
 			global.MinimapMinSize = settings.MinimapMinSize;
+			global.ViasNeighborRadius = settings.ViasNeighborRadius;
 
 			global.Save();
 
@@ -614,6 +621,7 @@ namespace DerouteSharp
 			settings.MinimapViewportColor = global.MinimapViewportColor;
 			settings.MinimapViewportOpacity = global.MinimapViewportOpacity;
 			settings.MinimapMinSize = global.MinimapMinSize;
+			settings.ViasNeighborRadius = global.ViasNeighborRadius;
 
 			// Save color settings
 
@@ -722,6 +730,7 @@ namespace DerouteSharp
 			global.MinimapViewportColor = settings.globalSettings.MinimapViewportColor;
 			global.MinimapViewportOpacity = settings.globalSettings.MinimapViewportOpacity;
 			global.MinimapMinSize = settings.globalSettings.MinimapMinSize;
+			global.ViasNeighborRadius = settings.globalSettings.ViasNeighborRadius;
 
 			global.Save();
 
@@ -835,6 +844,7 @@ namespace DerouteSharp
 			settings.globalSettings.MinimapViewportColor = new XmlColor(global.MinimapViewportColor);
 			settings.globalSettings.MinimapViewportOpacity = global.MinimapViewportOpacity;
 			settings.globalSettings.MinimapMinSize = global.MinimapMinSize;
+			settings.globalSettings.ViasNeighborRadius = global.ViasNeighborRadius;
 
 			// Save color settings
 

--- a/Deroute/Properties/Settings.Designer.cs
+++ b/Deroute/Properties/Settings.Designer.cs
@@ -778,5 +778,20 @@ namespace DerouteSharp.Properties {
                 this["MinimapMinSize"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1.5")]
+        public float ViasNeighborRadius
+        {
+            get
+            {
+                return ((float)(this["ViasNeighborRadius"]));
+            }
+            set
+            {
+                this["ViasNeighborRadius"] = value;
+            }
+        }
     }
 }

--- a/Deroute/Properties/Settings.settings
+++ b/Deroute/Properties/Settings.settings
@@ -191,5 +191,8 @@
     <Setting Name="MinimapMinSize" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">50</Value>
     </Setting>
+    <Setting Name="ViasNeighborRadius" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">1.5</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EntityBox/AddEntity.cs
+++ b/EntityBox/AddEntity.cs
@@ -70,7 +70,7 @@ namespace System.Windows.Forms
 						float dist = (float)Math.Sqrt(Math.Pow(entity.LambdaX - point.X, 2) +
 													   Math.Pow(entity.LambdaY - point.Y, 2));
 
-						if (dist <= 1.5F)
+						if (dist <= ViasNeighborRadius)
 							return null;
 					}
 				}

--- a/EntityBox/EntityBoxProperties.cs
+++ b/EntityBox/EntityBoxProperties.cs
@@ -320,6 +320,7 @@ namespace System.Windows.Forms
 		private bool _AutoPriority;
 		private string _viasGroundText;
 		private string _viasPowerText;
+		private float _viasNeighborRadius;
 
 		private void DefaultEntityAppearance()
 		{
@@ -382,6 +383,7 @@ namespace System.Windows.Forms
 			_viasGroundText = "1'b0";
 			_viasPowerText = "1'b1";
 			selectCellWithPorts = true;
+			_viasNeighborRadius = 1.5f;
 		}
 
 		[Category("Entity Appearance")]
@@ -759,6 +761,15 @@ namespace System.Windows.Forms
 		{
 			get { return _viasPowerText; }
 			set { _viasPowerText = value; }
+		}
+
+		[Category("Entity Appearance")]
+		[DefaultValue(1.5f)]
+		[Description("Radius in lambda for checking neighbor viases when adding new vias. Vias within this distance will not be created.")]
+		public float ViasNeighborRadius
+		{
+			get { return _viasNeighborRadius; }
+			set { _viasNeighborRadius = value; }
 		}
 
 		//


### PR DESCRIPTION
Вынесена настройка радиуса проверки окрестности при добавлении vias. Раньше значение было захардкожено (`1.5F`), теперь его можно менять в свойствах EntityBox или через Properties Window.

### Changes

**EntityBox/EntityBoxProperties.cs**
- Добавлено поле `_viasNeighborRadius`
- Добавлено свойство `ViasNeighborRadius` с `[DefaultValue(1.5f)]` и `[Category("Entity Appearance")]`
- Значение по умолчанию `1.5f` сохранено для обратной совместимости

**EntityBox/AddEntity.cs**
- Заменено захардкоженное `dist <= 1.5F` на `dist <= ViasNeighborRadius` в методе `AddVias()`

**Deroute/Properties/Settings.settings**
- Добавлена настройка `ViasNeighborRadius` типа `System.Single` со значением по умолчанию `1.5`

**Deroute/FormSettings.cs**
- Добавлено `ViasNeighborRadius` в класс `GlobalSettings` (чтение/запись)
- Добавлена сериализация в `LoadSettingsFromFile` / `SaveSettingsToFile`

### Motivation

При плотной расстановке vias с фиксированным радиусом `1.5F` невозможно добавить vias рядом друг с другом. Пользователи теперь могут уменьшить радиус (или отключить проверку, установив `0`), чтобы обойти это ограничение.